### PR TITLE
 Add build docs workflow 

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -18,7 +18,7 @@ jobs:
           name: Extract repo
           uses: actions/checkout@v4
         - id: setup_environment
-          name: Setup Pythomn environment
+          name: Setup Python environment
           uses: actions/setup-python@v5
           with:
             python-version: '3.12'


### PR DESCRIPTION
In order to use a reusable build documentation workflow across the simulation systems repositories the workflow first needs to be trialed in a safer environment. The git playground is a safe space to do this and thereby demonstrate a minimum liable product of this reusable workflow. But in order for the git playground to be able to call this workflow the workflow needs to be on the main branch of https://github.com/MetOffice/reusable-workflows.