### PR TITLE
Updating build-sphinx-docs workflow

### DIFF
--- a/.github/workflows/build-sphinx-docs.yaml
+++ b/.github/workflows/build-sphinx-docs.yaml
@@ -17,7 +17,7 @@ on:
           description: 'The repository to checkout the code from'
           required: false
           type: string
-          default: 'Pierre-siddall/growss'
+          default: 'MetOffice/growss'
 
       checkout-branch:
           description: 'The branch to checkout the repository from'


### PR DESCRIPTION
This PR attempts to provide a fix to the breaking build-sphinx-docs workflow by allowing it to be tested within the context of the MetOffice organaization. 