### PR TITLE
add cla check reusable workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,27 +3,3 @@
 Placeholder for a collection of
 [reusable workflows](https://docs.github.com/en/actions/learn-github-actions/reusing-workflows)
 for the Met Office Simulation Systems Repositories.
-
-## CLA Check
-
-A reusable action to test that a contributor has agreed to a CLA by adding their
-username to the CONTRIBUTORS file in that repository.
-
-### Usage
-
-```yaml
-name: CLA Check
-
-on:
-    pull_request:
-        types: [opened, synchronize, reopened]
-    workflow_dispatch:
-
-jobs:
-    cla_check:
-        uses: MetOffice/growss/.github/workflows/cla-check.yaml@main
-
-        # Optional
-        with:
-            runner: 'ubuntu-24.04'
-```

--- a/cla_check/README.md
+++ b/cla_check/README.md
@@ -1,0 +1,23 @@
+# CLA Check
+
+A reusable action to test that a contributor has agreed to a CLA by adding their
+username to the CONTRIBUTORS file in that repository.
+
+## Usage
+
+```yaml
+name: CLA Check
+
+on:
+    pull_request:
+        types: [opened, synchronize, reopened]
+    workflow_dispatch:
+
+jobs:
+    cla_check:
+        uses: MetOffice/growss/.github/workflows/cla-check.yaml@main
+
+        # Optional
+        with:
+            runner: 'ubuntu-24.04'
+```


### PR DESCRIPTION
Add a reusable workflow checking that the a contributor has added themselves to the CONTRIBUTORS file.

I've tested that this:

* fails when no username added and adds `required` label and a comment
* passes when username added to branch, removes `required` label, adds `signed` label
* passes and just just removes `required` label when username is on the base branch

We need to check that nothing is being deleted from the CONTRIBUTORS as well.