### PR TITLE
remove secret

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -7,9 +7,6 @@ on:
         required: false
         type: string
         default: 'ubuntu-24.04'
-    secrets:
-      gh_action_token:
-        required: true
 
 permissions:
   contents: read
@@ -23,7 +20,7 @@ jobs:
       - name: Checkout base branch and check for contributor status
         uses: actions/checkout@v5
         with:
-          token: ${{ secrets.gh_action_token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Determine if contributor exists in base
@@ -50,7 +47,7 @@ jobs:
         if: steps.check_contributor_base.outputs.on_base != 'true'
         uses: actions/checkout@v5
         with:
-          token: ${{ secrets.gh_action_token }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Determine if contributor exists in PR branch
@@ -74,7 +71,7 @@ jobs:
         # success/failure to manage labels correctly
         if: always()
         with:
-          github-token: ${{ secrets.gh_action_token }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const signedOnBase = '${{ steps.check_contributor_base.outputs.on_base }}' === 'true';
             // Default signed status is false if the second check wasn't run

--- a/cla_check/README.md
+++ b/cla_check/README.md
@@ -14,8 +14,7 @@ on:
 jobs:
     cla_check:
         uses: MetOffice/growss/.github/workflows/cla-check.yaml@main
-        secrets:
-            gh_action_token: ${{ secrets.GITHUB_TOKEN }}
+
         # Optional
         with:
             runner: 'ubuntu-24.04'


### PR DESCRIPTION
It was thought that to get this working we needed to pass the secret from the calling repo. This was wrong as the actual issue was not using `pull_request_target`. I've tested that this works by pointing the git_playground at the hash of the original commit (without the secret) while using pull_request_target