### PR TITLE
Fortran linting workflow fix

### DIFF
--- a/.github/workflows/fortran-lint.yaml
+++ b/.github/workflows/fortran-lint.yaml
@@ -11,14 +11,17 @@ on:
       runner:
         description: "The runner to use for the job"
         required: false
+        type: string
         default: "ubuntu-latest"
       timeout:
         description: "The maximum time in minutes the job can run for"
         required: false
+        type: number
         default: 10
       python-version:
         description: "The Python version to use"
         required: false
+        type: string
         default: "3.14"
 
 jobs:


### PR DESCRIPTION
There is a tiny issue when the Fortran linting workflow is called in the https://github.com/MetOffice/git_playground repository where it requires a virtual environment to install fortitude this can be fixed by adding the `--system` flag to the install if fortitude with uv. 

Update: The purpose of this PR has now changed to revert the workflow back to a functional state. Please see the appended comment https://github.com/MetOffice/growss/pull/39#issuecomment-3553582268 for more detail. 