### PR TITLE
make grep case insensitive

### DIFF
--- a/.github/workflows/check-cr-approved.yaml
+++ b/.github/workflows/check-cr-approved.yaml
@@ -27,7 +27,7 @@ jobs:
           echo "Running on PR #$PR_NUMBER in Repository $REPO"
 
           # -- 1. Extract the assigned Code Reviewer from the PR body
-          CODE_REVIEWER=$(echo "$PR_BODY" | grep -oiP "Code Reviewer:\s?@\K([a-z\d](?:[a-z\d]|-(?=[a-z\d])){0,38})") || true
+          CODE_REVIEWER=$(echo "$PR_BODY" | grep -oP "Code Reviewer:\s?@\K([\w\-]{1,39})\b") || true
 
           if [[ -z "$CODE_REVIEWER" ]]; then
             echo "::error::No 'Code Reviewer: @<username>' found in the PR body."


### PR DESCRIPTION
The grep in the check-cr-approved action doesn't allow for usernames with capitalised letters. Make the grep case insensitive to allow for this