### PR TITLE
Add logic to check CR in progress for trivial review

### DIFF
--- a/.github/workflows/track-review-project.yaml
+++ b/.github/workflows/track-review-project.yaml
@@ -114,7 +114,7 @@ jobs:
 
           [[ ! -z "$scitech_reviewer" ]] && [[ "$sr_requested" -eq 0 ]] && [[ "$sr_approved" -eq 0 ]] && [[ "$sr_changes" -eq 0 ]] && echo "SR_REQUEST_REQUIRED=true" >> $GITHUB_ENV
 
-          if [[ -z "$scitech_reviewer" ]] && [[ "$cr_requested" -gt 0 || "$cr_approved" -gt 0 || "cr_changes" -gt 0 ]]; then
+          if [[ -z "$scitech_reviewer" ]] && [[ "$cr_requested" -gt 0 || "$cr_approved" -gt 0 || "$cr_changes" -gt 0 ]]; then
             echo "No SR set and CR in progress so assuming this is trivial"
           else
             if [[ "$sr_approved" -eq 0 ]]; then


### PR DESCRIPTION
Currently, once the code reviewer requests changes or approves a PR the logic to recognise a trivial PR breaks. Add checks for these states to the workflow. 