### PR TITLE
update to use base_ref, not base_sha

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -108,10 +108,7 @@ jobs:
 
             git fetch origin ${{ github.event.pull_request.base.ref }}
 
-            # Use the base SHA directly for comparison (works with forks)
-            BASE_SHA="${{ github.event.pull_request.base.sha }}"
-
-            CHANGED_FILES=$(git diff --name-only $BASE_SHA)
+            CHANGED_FILES=$(git diff --name-only $GITHUB_BASE_REF)
 
             if echo "$CHANGED_FILES" | grep -q "^CONTRIBUTORS.md$"; then
               echo "modified=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
In the CLA action the merge ref of a PR is currently compared against the Base SHA to see if the CONTRIBUTORS file has been modified in that branch. 

* The merge ref represents the latest version of the target branch merged with the PR branch (and only exists if there are no conflicts).
* The Base SHA represents the latest commit shared between the target and PR branch (either the point the PR branch was created or the last time the PR branch was updated)

This is incorrect as the merge ref may well contain additional commits since the Base SHA, some of which might change the CONTRIBUTORS, resulting in incorrect failures. Instead, use the Base Ref value, which returns the name of the target branch, and therefore we'll be comparing against the latest commit.