### PR TITLE
Further refactor cla-check workfllo

### DIFF
--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -37,8 +37,8 @@ jobs:
         id: validate_author
         run: |
           AUTHOR="${{ github.event.pull_request.user.login }}"
-          # GitHub usernames: alphanumeric + hyphen, 1-39 chars, cannot start/end with hyphen
-          # Cannot contain consecutive hyphens
+          # GitHub usernames: alphanumeric + hyphen, 1-39 chars,
+          # cannot start/end with hyphen, cannot contain consecutive hyphens
           if [[ ! "$AUTHOR" =~ ^[a-zA-Z0-9]([a-zA-Z0-9]|-[a-zA-Z0-9]){0,37}[a-zA-Z0-9]?$ ]]; then
             echo "::error::Invalid GitHub username format detected: $AUTHOR"
             echo "This may indicate a security issue or data integrity problem."
@@ -51,10 +51,8 @@ jobs:
         id: check_contributor_base
         working-directory: ./base_branch
         run: |
-          # AUTHOR="${{ github.event.pull_request.user.login }}"
           AUTHOR="${{ steps.validate_author.outputs.validated_author }}"
           if [ -f "CONTRIBUTORS.md" ]; then
-            # if grep -qE "\|\s*$AUTHOR\s*\|" CONTRIBUTORS.md; then
             if grep -qP "^\s*\|\s*\Q$AUTHOR\E\s*\|" CONTRIBUTORS.md; then
               echo "on_base=true" >> $GITHUB_OUTPUT
               echo "🎉 $AUTHOR has already signed the CLA on base branch."
@@ -79,7 +77,6 @@ jobs:
         id: check_contributor_pr
         working-directory: pr_branch
         run: |
-          # AUTHOR="${{ github.event.pull_request.user.login }}"
           AUTHOR="${{ steps.validate_author.outputs.validated_author }}"
           if [ -f "CONTRIBUTORS.md" ]; then
             # if grep -qE "\|\s*$AUTHOR\s*\|" CONTRIBUTORS.md; then
@@ -299,7 +296,8 @@ jobs:
               console.log('✅ New contributor has signed the CLA in PR branch.');
               await Promise.allSettled([
                 github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'cla-required' }),
-                github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'cla-modified' })
+                github.rest.issues.removeLabel({ owner, repo, issue_number, name: 'cla-modified' }),
+                github.rest.issues.addLabels({ owner, repo, issue_number, labels: ['cla-signed'] })
               ]);
 
               // Delete old CLA comments since CLA is now signed

--- a/cla-check/README.md
+++ b/cla-check/README.md
@@ -10,7 +10,7 @@ Contributor License Agreement (CLA) by checking their presence in the
 - 🏷️ Manages PR labels (`cla-signed`, `cla-required`, `cla-modified`)
 - 💬 Posts helpful comments guiding contributors through the CLA process
 - 🔄 Validates both base and PR branches for existing signatures
-- 🛡️ Prevents unauthorized modifications to the `CONTRIBUTORS.md` file
+- 🛡️ Prevents unauthorised modifications to the `CONTRIBUTORS.md` file
 
 ## Usage
 


### PR DESCRIPTION
Refactored cla-check workflow with:

- ability of use custom cla-url (only https)
- step to validate GitHub username (apparently code injection is slim but possible via this route!)
- avoid potential regex injection attack (replace `--extended-regexp` with `--perl-regexp`; :warning: this requires **GNU grep** which is available on GitHub standard runners, may not be available on mac-os)
  - using `\Q...\E` in grep escapes special characters in Perl regex
  - anchor pattern with `^\s*\|` - Reduces false positives by matching start of line
- protection against Path traversal in Git operations - only check for exact `CONTRIBUTORS.md` file with `git diff` (not everything)
- README with clear structure and examples

Demo available at: https://github.com/MetOffice/git_playground/pull/119

ℹ️ Need a final tidy (remove the commented out codes, following your review)