### PR TITLE
Add fortitude config path parameter

### DIFF
--- a/.github/workflows/fortran-lint.yaml
+++ b/.github/workflows/fortran-lint.yaml
@@ -95,5 +95,6 @@ jobs:
             ${{ inputs.show-fixes && '--show-fixes' || '' }} \
             ${{ inputs.show-statistics && '--statistics' || '' }} \
             --file-extensions=${{ inputs.file-extensions }} \
+            --config-file=${{ inputs.config-path }} \
             ${{ inputs.source-path }}
         continue-on-error: ${{ !inputs.fail-on-error }}

--- a/.github/workflows/fortran-lint.yaml
+++ b/.github/workflows/fortran-lint.yaml
@@ -54,7 +54,7 @@ on:
         type: string
         default: "."
       config-path:
-        description: "Path to configuration file containing fortitude rules"
+        description: "Path to configuration file with rules"
         required: false
         type: string
         default: "fortitude.toml"

--- a/.github/workflows/fortran-lint.yaml
+++ b/.github/workflows/fortran-lint.yaml
@@ -53,6 +53,11 @@ on:
         required: false
         type: string
         default: "."
+      config-path:
+        description: "Path to configuration file containing fortitude rules"
+        required: false
+        type: string
+        default: "fortitude.toml"
       fail-on-error:
         description: "Whether to fail the workflow on linting errors"
         required: false

--- a/.github/workflows/fortran-lint.yaml
+++ b/.github/workflows/fortran-lint.yaml
@@ -57,7 +57,6 @@ on:
         description: "Path to configuration file with rules"
         required: false
         type: string
-        default: "fortitude.toml"
       fail-on-error:
         description: "Whether to fail the workflow on linting errors"
         required: false
@@ -95,6 +94,6 @@ jobs:
             ${{ inputs.show-fixes && '--show-fixes' || '' }} \
             ${{ inputs.show-statistics && '--statistics' || '' }} \
             --file-extensions=${{ inputs.file-extensions }} \
-            --config-file=${{ inputs.config-path }} \
+            ${{ inputs.config-path && format('--config-file={0}', inputs.config-path) || '' }} \
             ${{ inputs.source-path }}
         continue-on-error: ${{ !inputs.fail-on-error }}

--- a/fortran-lint/README.md
+++ b/fortran-lint/README.md
@@ -95,7 +95,7 @@ jobs:
 | `show-fixes`        | Show suggested fixes                    | No       | `true`                          | boolean |
 | `show-statistics`   | Show linting statistics                 | No       | `true`                          | boolean |
 | `source-path`       | Path to source code directory           | No       | `.`                             | string  |
-| `config-path`       | Path to configuration file with rules   | No       | `fortitude.toml`                | string  |
+| `config-path`       | Path to configuration file with rules   | No       |                                 | string  |
 | `fail-on-error`     | Fail workflow on linting errors         | No       | `true`                          | boolean |
 | `enable-cache`      | Enable UV cache                         | No       | `false`                         | boolean |
 

--- a/fortran-lint/README.md
+++ b/fortran-lint/README.md
@@ -72,6 +72,7 @@ jobs:
       # Linting options
       file-extensions: "f90,F90,pf,PF"
       source-path: "./src"
+      config-path: ".github/configs/fortitude.toml"
       respect-gitignore: true
       show-fixes: true
       show-statistics: true
@@ -94,6 +95,7 @@ jobs:
 | `show-fixes`        | Show suggested fixes                    | No       | `true`                          | boolean |
 | `show-statistics`   | Show linting statistics                 | No       | `true`                          | boolean |
 | `source-path`       | Path to source code directory           | No       | `.`                             | string  |
+| `config-path`       | Path to configuration file with rules   | No       | `fortitude.toml`                | string  |
 | `fail-on-error`     | Fail workflow on linting errors         | No       | `true`                          | boolean |
 | `enable-cache`      | Enable UV cache                         | No       | `false`                         | boolean |
 


### PR DESCRIPTION
# PR Summary

Code Reviewer: <!-- CR id, filled by SSD --> @t00sa 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

This PR adds a `config-path` parameter to the Fortran linting workflow to allow developers to configure the location of their `fortitude.toml` file. 

closes #77 

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's style guidelines
- [x] The modified workflow's README has been updated, if required
- [ ] The changes have been sufficiently tested (please describe)

## AI Assistance and Attribution

- [ ] Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)

<!-- If AI has been used, please provide more details here -->

# Code Review

- [ ] The changes are approriate and testing has been sufficient
