### PR TITLE
Allow a list of skippable authors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -28,4 +28,4 @@ Code Reviewer: <!-- CR id, filled by SSD -->
 
 # Code Review
 
-- [ ] The changes are approriate and testing has been sufficient
+- [ ] The changes are appropriate and testing has been sufficient

--- a/.github/workflows/cla-check.yaml
+++ b/.github/workflows/cla-check.yaml
@@ -17,6 +17,11 @@ on:
         required: false
         type: string
         default: 'https://github.com/MetOffice/Momentum/blob/main/CLA.md'
+      ignore-users:
+        description: 'User names which can be ignored (e.g. dependabot) - should be useable as a bash array'
+        required: false
+        type: string
+        default: 'dependabot'
 
 permissions:
   contents: read
@@ -52,7 +57,9 @@ jobs:
         working-directory: ./base_branch
         run: |
           AUTHOR="${{ steps.validate_author.outputs.validated_author }}"
-          if [ -f "CONTRIBUTORS.md" ]; then
+          if [[ "${{inputs.ignore-users}}" == *"$AUTHOR"* ]]; then
+            echo "⏭️ Skipping verification of $AUTHOR" > $GITHUB_OUTPUT
+          elif [ -f "CONTRIBUTORS.md" ]; then
             if grep -qP "^\s*\|\s*\Q$AUTHOR\E\s*\|" CONTRIBUTORS.md; then
               echo "on_base=true" >> $GITHUB_OUTPUT
               echo "🎉 $AUTHOR has already signed the CLA on base branch."

--- a/cla-check/README.md
+++ b/cla-check/README.md
@@ -7,6 +7,8 @@ Contributor License Agreement (CLA) by checking their presence in the
 ## Features
 
 - ✅ Automatically checks if PR authors have signed the CLA
+  - Allows skipping of authors using input `ignore-users` to allow
+    dependabot and similar not to be added to the users list.
 - 🏷️ Manages PR labels (`cla-signed`, `cla-required`, `cla-modified`)
 - 💬 Posts helpful comments guiding contributors through the CLA process
 - 🔄 Validates both base and PR branches for existing signatures
@@ -52,14 +54,18 @@ jobs:
       # cla-url: "https://gitlab.com/yourorg/yourrepo/-/blob/main/CLA.md"
       # GitHub runner to use
       runner: "ubuntu-24.04"
+      # Allow the following users to make PR's without
+      # being added to CONTRIBUTORS.md
+      ingore-users: "dependabot ruffbot ghostadminperson"
 ```
 
 ## Input Parameters
 
-| Parameter | Description                                   | Required | Default                                                  |
-| --------- | --------------------------------------------- | -------- | -------------------------------------------------------- |
-| `cla-url` | URL to the CLA document (any valid HTTPS URL) | No       | `https://github.com/MetOffice/Momentum/blob/main/CLA.md` |
-| `runner`  | GitHub Actions runner to use for the job      | No       | `ubuntu-24.04`                                           |
+| Parameter      | Description                                   | Required | Default                                                  |
+| -------------- | --------------------------------------------- | -------- | -------------------------------------------------------- |
+| `cla-url`      | URL to the CLA document (any valid HTTPS URL) | No       | `https://github.com/MetOffice/Momentum/blob/main/CLA.md` |
+| `runner`       | GitHub Actions runner to use for the job      | No       | `ubuntu-24.04`                                           |
+| `ignore-users` | List of users to not check                    | No       | `dependabot`                                             |
 
 **Note:** The `cla-url` can point to any publicly accessible web page containing
 your CLA terms (e.g., GitHub, GitLab, Confluence, your organization's website,


### PR DESCRIPTION
Default to include dependabot

# PR Summary

closes 83 - allow user to skip CLA verification for some user names, to allow for merge of dependabot branches.

Code Reviewer: @yaswant 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes
     useful for reviewers -->

## Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's style guidelines
- [x] The modified workflow's README has been updated, if required
- [ ] The changes have been sufficiently tested (please describe)

## AI Assistance and Attribution

- [ ] ~Some of the content of this change has been produced with the assistance
      of _Generative AI tool name_ (e.g., Met Office Github Copilot Enterprise,
      Github Copilot Personal, ChatGPT GPT-4, etc) and I have followed the
      [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html)
      (including attribution labels)~
      
 **Natural Stupidity only in my PR's**

<!-- If AI has been used, please provide more details here -->

# Code Review

- [ ] The changes are appropriate and testing has been sufficient
