### PR TITLE
Add deprecated warnings to the legacy build and deploy sphinx workflows

### DIFF
--- a/.github/workflows/build-sphinx-docs.yaml
+++ b/.github/workflows/build-sphinx-docs.yaml
@@ -4,7 +4,7 @@
 # under which the code may be used.
 # ------------------------------------------------------------------------------
 # Some of the content of this file has been produced with the assistance of
-# Claude Opus 4.8."
+# Claude Opus 4.8.
 
 name: Build Sphinx Docs
 

--- a/.github/workflows/build-sphinx-docs.yaml
+++ b/.github/workflows/build-sphinx-docs.yaml
@@ -60,7 +60,12 @@ jobs:
     steps:
       - name: Deprecation warning
         run: |
-          echo "::warning title=Deprecated workflow::This reusable workflow is deprecated and will be removed in the future. Please migrate to the sphinx-docs.yaml workflow."
+          echo "::warning title=Workflow Deprecated::This reusable workflow will be removed in future release. Please migrate to sphinx-docs.yaml workflow."
+
+          echo "### ⚠️ Deprecation Notice" >> $GITHUB_STEP_SUMMARY
+echo "The \`build-sphinx-docs\` reusable workflow has been **deprecated** and will be removed in the next release." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> **Migration Path:** Please transition your workflows to use the new unified action instead. Refer to the [sphinx-docs workflow guide](https://github.com/MetOffice/growss/tree/main/sphinx-docs) for details." >> $GITHUB_STEP_SUMMARY
 
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/build-sphinx-docs.yaml
+++ b/.github/workflows/build-sphinx-docs.yaml
@@ -62,7 +62,7 @@ jobs:
     steps:
       - name: Deprecation warning
         run: |
-          echo "::warning title=Workflow Deprecated::This reusable workflow will be removed in future release. Please migrate to sphinx-docs.yaml workflow."
+          echo "::warning title=Workflow Deprecated::This reusable workflow will be removed in next release. Please migrate to sphinx-docs.yaml workflow."
 
           echo "### ⚠️ Deprecation Notice" >> $GITHUB_STEP_SUMMARY
           echo "The \`build-sphinx-docs\` reusable workflow has been **deprecated** and will be removed in the next release." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/build-sphinx-docs.yaml
+++ b/.github/workflows/build-sphinx-docs.yaml
@@ -3,6 +3,8 @@
 # The file LICENCE, distributed with this code, contains details of the terms
 # under which the code may be used.
 # ------------------------------------------------------------------------------
+# Some of the content of this file has been produced with the assistance of
+# Claude Opus 4.8."
 
 name: Build Sphinx Docs
 

--- a/.github/workflows/build-sphinx-docs.yaml
+++ b/.github/workflows/build-sphinx-docs.yaml
@@ -51,6 +51,10 @@ jobs:
       SPHINX_OPTS: ${{ inputs.sphinx-opts }}
       BUILD_DIR: ${{ inputs.build-directory }}
     steps:
+      - name: Deprecation warning
+        run: |
+          echo "::warning title=Deprecated workflow::This reusable workflow is deprecated and will be removed in the future. Please migrate to the sphinx-docs.yaml workflow."
+
       - name: Checkout repository
         uses: actions/checkout@v6
 

--- a/.github/workflows/build-sphinx-docs.yaml
+++ b/.github/workflows/build-sphinx-docs.yaml
@@ -63,7 +63,7 @@ jobs:
           echo "::warning title=Workflow Deprecated::This reusable workflow will be removed in future release. Please migrate to sphinx-docs.yaml workflow."
 
           echo "### ⚠️ Deprecation Notice" >> $GITHUB_STEP_SUMMARY
-echo "The \`build-sphinx-docs\` reusable workflow has been **deprecated** and will be removed in the next release." >> $GITHUB_STEP_SUMMARY
+          echo "The \`build-sphinx-docs\` reusable workflow has been **deprecated** and will be removed in the next release." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "> **Migration Path:** Please transition your workflows to use the new unified action instead. Refer to the [sphinx-docs workflow guide](https://github.com/MetOffice/growss/tree/main/sphinx-docs) for details." >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/deploy-sphinx-docs.yaml
+++ b/.github/workflows/deploy-sphinx-docs.yaml
@@ -4,7 +4,7 @@
 # under which the code may be used.
 # ------------------------------------------------------------------------------
 # Some of the content of this file has been produced with the assistance of
-# Claude Opus 4.8."
+# Claude Opus 4.8.
 
 name: Deploy Sphinx Docs
 

--- a/.github/workflows/deploy-sphinx-docs.yaml
+++ b/.github/workflows/deploy-sphinx-docs.yaml
@@ -36,7 +36,12 @@ jobs:
     steps:
       - name: Deprecation warning
         run: |
-          echo "::warning title=Deprecated workflow::This reusable workflow is deprecated and will be removed in the future. Please migrate to the sphinx-docs.yaml workflow."
+          echo "::warning title=Workflow Deprecated::This reusable workflow will be removed in future release. Please migrate to sphinx-docs.yaml workflow."
+
+          echo "### ⚠️ Deprecation Notice" >> $GITHUB_STEP_SUMMARY
+          echo "The \`deploy-sphinx-docs\` reusable workflow has been **deprecated** and will be removed in the next release." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "> **Migration Path:** Please transition your workflows to use the new unified action instead. Refer to the [sphinx-docs workflow guide](https://github.com/MetOffice/growss/tree/main/sphinx-docs) for details." >> $GITHUB_STEP_SUMMARY
 
       - name: Configure GitHub Pages
         id: configure

--- a/.github/workflows/deploy-sphinx-docs.yaml
+++ b/.github/workflows/deploy-sphinx-docs.yaml
@@ -3,6 +3,8 @@
 # The file LICENCE, distributed with this code, contains details of the terms
 # under which the code may be used.
 # ------------------------------------------------------------------------------
+# Some of the content of this file has been produced with the assistance of
+# Claude Opus 4.8."
 
 name: Deploy Sphinx Docs
 

--- a/.github/workflows/deploy-sphinx-docs.yaml
+++ b/.github/workflows/deploy-sphinx-docs.yaml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Deprecation warning
         run: |
-          echo "::warning title=Workflow Deprecated::This reusable workflow will be removed in future release. Please migrate to sphinx-docs.yaml workflow."
+          echo "::warning title=Workflow Deprecated::This reusable workflow will be removed in the next release. Please migrate to sphinx-docs.yaml workflow."
 
           echo "### ⚠️ Deprecation Notice" >> $GITHUB_STEP_SUMMARY
           echo "The \`deploy-sphinx-docs\` reusable workflow has been **deprecated** and will be removed in the next release." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-sphinx-docs.yaml
+++ b/.github/workflows/deploy-sphinx-docs.yaml
@@ -29,6 +29,10 @@ jobs:
       pages: write
       id-token: write
     steps:
+      - name: Deprecation warning
+        run: |
+          echo "::warning title=Deprecated workflow::This reusable workflow is deprecated and will be removed in the future. Please migrate to the sphinx-docs.yaml workflow."
+
       - name: Configure GitHub Pages
         id: configure
         uses: actions/configure-pages@v5


### PR DESCRIPTION
# PR Summary

<!-- One-line Summary -->

Code Reviewer: <!-- CR id, filled by SSD --> @yaswant 

<!-- To be completed by the developer -->

<!-- Provide a brief description of the changes in this PR, including any notes useful for reviewers -->

This PR adds a deprecated warning to a couple of legacy workflows to ensure that users migrate to the `sphinx-docs.yaml` workflow.

## :white_check_mark: Code Quality Checklist

(_Some checks are automatically carried out via the CI pipeline_)

- [x] I have performed a self-review of my own code
- [x] My code follows the project's style guidelines
- [x] The modified workflow's README has been updated, if required
- [x] The changes have been sufficiently tested (please describe)

## :robot: AI Assistance and Attribution

- [x] Some of the content of this change has been produced with the assistance of _Generative AI tool name_ (e.g., Met Office GitHub Copilot Enterprise, GitHub Copilot Personal, ChatGPT GPT-4, etc) and I have followed the [Simulation Systems AI policy](https://metoffice.github.io/simulation-systems/FurtherDetails/ai.html) (including attribution labels)

<!-- If AI has been used, please provide more details here -->

## :computer: Code Review

- [ ] The changes are appropriate and testing has been sufficient
